### PR TITLE
Add the requirement to wand.json when calling wand add

### DIFF
--- a/lib/cli/commands/add.ex
+++ b/lib/cli/commands/add.ex
@@ -17,7 +17,6 @@ defmodule Wand.CLI.Commands.Add do
   ## Options
   The available flags depend on if wand is being used to add a single package, or multiple packages. Flags that can only be used in single-package-mode are denoted with (s).
   <pre>
-  --around            Stay within the minor version provided
   --compile           Run mix compile after adding (default: **true**)
   --compile-env   (s) The environment for the dependency (default: **prod**)
   --dev               Include the dependency in the dev environment
@@ -36,6 +35,7 @@ defmodule Wand.CLI.Commands.Add do
   --sparse        (s) Checkout a given directory inside git
   --submodules    (s) Initialize submodules for the repo
   --test              Include the dependency in the test environment
+  --tilde             Stay within the minor version provided
   --in-umbrella   (s) Sets a path dependency pointing to ../app
   </pre>
   """
@@ -61,17 +61,17 @@ defmodule Wand.CLI.Commands.Add do
   end
 
   defmodule Package do
+    @default_requirement Wand.Mode.get_requirement(:caret, :latest)
     defstruct compile: true,
               compile_env: nil,
               details: %Hex{},
               download: true,
               environments: [:all],
-              mode: :normal,
               name: nil,
               optional: nil,
               override: nil,
               read_app_file: nil,
-              requirement: :latest,
+              requirement: @default_requirement,
               runtime: nil
   end
 

--- a/lib/cli/commands/add.ex
+++ b/lib/cli/commands/add.ex
@@ -61,7 +61,7 @@ defmodule Wand.CLI.Commands.Add do
   end
 
   defmodule Package do
-    @default_requirement Wand.Mode.get_requirement(:caret, :latest)
+    @default_requirement Wand.Mode.get_requirement!(:caret, :latest)
     defstruct compile: true,
               compile_env: nil,
               details: %Hex{},

--- a/lib/cli/commands/add/execute.ex
+++ b/lib/cli/commands/add/execute.ex
@@ -29,10 +29,10 @@ defmodule Wand.CLI.Commands.Add.Execute do
     end
   end
 
-  defp get_dependency(%Package{name: name, requirement: {:latest, mode}}=package) do
+  defp get_dependency(%Package{name: name, requirement: {:latest, mode}}) do
     case Wand.Hex.releases(name) do
       {:ok, [version | _]} ->
-        requirement = Wand.Mode.get_requirement(mode, version)
+        requirement = Wand.Mode.get_requirement!(mode, version)
         {:ok, %Dependency{name: name, requirement: requirement}}
       {:error, error} -> {:error, {error, name}}
     end

--- a/lib/cli/commands/add/execute.ex
+++ b/lib/cli/commands/add/execute.ex
@@ -38,6 +38,11 @@ defmodule Wand.CLI.Commands.Add.Execute do
     end
   end
 
+  defp get_dependency(%Package{}=package) do
+    requirement = get_requirement(package.requirement, package.mode)
+    {:ok, %Dependency{name: package.name, requirement: requirement}}
+  end
+
   defp add_dependencies(file, dependencies) do
     Enum.reduce_while(dependencies, {:ok, file}, fn(dependency, {:ok, file}) ->
       case WandFile.add(file, dependency) do
@@ -49,6 +54,10 @@ defmodule Wand.CLI.Commands.Add.Execute do
 
   defp get_requirement(version, :normal) do
     "~> " <> version
+  end
+
+  defp get_requirement(version, :exact) do
+    "== " <> version
   end
 
   defp load_file() do

--- a/lib/cli/commands/add/execute.ex
+++ b/lib/cli/commands/add/execute.ex
@@ -29,18 +29,17 @@ defmodule Wand.CLI.Commands.Add.Execute do
     end
   end
 
-  defp get_dependency(%Package{name: name, requirement: :latest}=package) do
+  defp get_dependency(%Package{name: name, requirement: {:latest, mode}}=package) do
     case Wand.Hex.releases(name) do
       {:ok, [version | _]} ->
-        requirement = get_requirement(version, package.mode)
+        requirement = Wand.Mode.get_requirement(mode, version)
         {:ok, %Dependency{name: name, requirement: requirement}}
       {:error, error} -> {:error, {error, name}}
     end
   end
 
   defp get_dependency(%Package{}=package) do
-    requirement = get_requirement(package.requirement, package.mode)
-    {:ok, %Dependency{name: package.name, requirement: requirement}}
+    {:ok, %Dependency{name: package.name, requirement: package.requirement}}
   end
 
   defp add_dependencies(file, dependencies) do
@@ -50,14 +49,6 @@ defmodule Wand.CLI.Commands.Add.Execute do
         {:error, reason} -> {:halt, {:error, :add_dependency, reason}}
       end
     end)
-  end
-
-  defp get_requirement(version, :normal) do
-    "~> " <> version
-  end
-
-  defp get_requirement(version, :exact) do
-    "== " <> version
   end
 
   defp load_file() do

--- a/lib/cli/commands/add/help.ex
+++ b/lib/cli/commands/add/help.ex
@@ -86,4 +86,20 @@ defmodule Wand.CLI.Commands.Add.Help do
     |> Wand.CLI.Display.print()
   end
 
+  def help({:invalid_version, package}) do
+    """
+    #{package} contains an invalid version
+    A version must conform to the SemVar schema.
+
+    Some valid example versions are:
+    <pre>
+    3.1.0
+    0.0.1
+    2.0.0-dev
+    </pre>
+
+    Note that versions are not requirements and don't contain >=, ~> etc.
+    """
+    |> Wand.CLI.Display.print()
+  end
 end

--- a/lib/cli/commands/add/validate.ex
+++ b/lib/cli/commands/add/validate.ex
@@ -1,5 +1,6 @@
 defmodule Wand.CLI.Commands.Add.Validate do
   alias Wand.CLI.Commands.Add.{Git, Hex, Package, Path}
+
   def validate(args) do
     flags = allowed_flags(args)
     {switches, [_ | commands], errors} = OptionParser.parse(args, strict: flags)
@@ -8,15 +9,19 @@ defmodule Wand.CLI.Commands.Add.Validate do
       :ok ->
         requirements = get_requirements(commands, switches)
         get_packages(commands, switches, requirements)
-      error -> error
+
+      error ->
+        error
     end
   end
 
   defp get_packages([], _switches, _requirements), do: {:error, :missing_package}
 
-  defp get_packages(_names, _switches, {:error, _}=error), do: error
+  defp get_packages(_names, _switches, {:error, _} = error), do: error
+
   defp get_packages(names, switches, {:ok, requirements}) do
     base_package = get_base_package(switches)
+
     packages =
       Enum.zip(names, requirements)
       |> Enum.map(fn {name, requirement} ->
@@ -24,9 +29,9 @@ defmodule Wand.CLI.Commands.Add.Validate do
         type = package_type(switches)
 
         %Package{
-          base_package |
-          name: name,
-          requirement: requirement,
+          base_package
+          | name: name,
+            requirement: requirement
         }
         |> add_details(type, switches)
       end)
@@ -67,16 +72,19 @@ defmodule Wand.CLI.Commands.Add.Validate do
   end
 
   defp add_details(package, :git, switches) do
-    {uri, ref} = case String.split(Keyword.fetch!(switches, :git), "#", parts: 2) do
-      [uri] -> {uri, nil}
-      [uri, ref] -> {uri, ref}
-    end
+    {uri, ref} =
+      case String.split(Keyword.fetch!(switches, :git), "#", parts: 2) do
+        [uri] -> {uri, nil}
+        [uri, ref] -> {uri, ref}
+      end
+
     details = %Git{
       uri: uri,
       sparse: Keyword.get(switches, :sparse),
       submodules: Keyword.get(switches, :submodules),
       ref: ref
     }
+
     %Package{package | details: details}
   end
 
@@ -133,11 +141,14 @@ defmodule Wand.CLI.Commands.Add.Validate do
   end
 
   defp get_requirements(names, switches) do
-    requirements = Enum.map(names, fn name ->
-      version = split_name(name)
-      |> elem(1)
-      {name, Wand.Mode.get_requirement(get_mode(switches), version)}
-    end)
+    requirements =
+      Enum.map(names, fn name ->
+        version =
+          split_name(name)
+          |> elem(1)
+
+        {name, Wand.Mode.get_requirement(get_mode(switches), version)}
+      end)
 
     case Enum.find(requirements, &(&1 |> elem(1) |> elem(0) == :error)) do
       nil ->
@@ -146,8 +157,11 @@ defmodule Wand.CLI.Commands.Add.Validate do
           |> elem(1)
           |> Enum.unzip()
           |> elem(1)
+
         {:ok, requirements}
-      {name, {:error, reason}} -> {:error, {reason, name}}
+
+      {name, {:error, reason}} ->
+        {:error, {reason, name}}
     end
   end
 
@@ -167,7 +181,7 @@ defmodule Wand.CLI.Commands.Add.Validate do
       ],
       path: [
         path: :string,
-        in_umbrella: :boolean,
+        in_umbrella: :boolean
       ],
       git: [
         git: :string,
@@ -175,11 +189,11 @@ defmodule Wand.CLI.Commands.Add.Validate do
         submodules: :boolean
       ],
       umbrella: [
-        in_umbrella: :boolean,
+        in_umbrella: :boolean
       ],
       single_package: [
         compile_env: :string,
-        read_app_file: :boolean,
+        read_app_file: :boolean
       ],
       multi_package: [
         compile: :boolean,
@@ -195,7 +209,7 @@ defmodule Wand.CLI.Commands.Add.Validate do
         runtime: :boolean,
         test: :boolean,
         tilde: :boolean
-      ],
+      ]
     }
 
     {switches, [_ | commands], _errors} = OptionParser.parse(args)

--- a/lib/cli/display.ex
+++ b/lib/cli/display.ex
@@ -81,12 +81,13 @@ defmodule Wand.CLI.Display do
   end
 
   def error(message) do
-    ANSI.red() <> convert(message) <> ANSI.default_color()
+    (ANSI.red() <> convert(message) <> ANSI.default_color())
     |> stderr()
   end
 
   defp convert(message) do
     {blocks, context} = Wand.CLI.Display.Renderer.parse(message)
+
     Wand.CLI.Display.Renderer.render(blocks, context)
     |> elem(1)
     |> pretty

--- a/lib/cli/errors.ex
+++ b/lib/cli/errors.ex
@@ -5,7 +5,7 @@ defmodule Wand.CLI.Errors do
     package_not_found: 66,
     package_already_exists: 67,
     hex_api_error: 68,
-    file_write_error: 69,
+    file_write_error: 69
   }
 
   def code(key), do: Map.fetch!(@errors, key)

--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -19,17 +19,20 @@ defmodule Wand.Hex do
   defp parse_response({:ok, %Response{status_code: 404}}) do
     {:error, :not_found}
   end
+
   defp parse_response({:ok, %Response{}}), do: {:error, :bad_response}
   defp parse_response({:error, %Error{}}), do: {:error, :no_connection}
 
   defp parse_json({:ok, %{"releases" => releases}}) do
-    releases = Enum.map(releases, &Map.get(&1, "version"))
-    |> Enum.reject(&(&1 == nil or Version.parse(&1) == :error))
+    releases =
+      Enum.map(releases, &Map.get(&1, "version"))
+      |> Enum.reject(&(&1 == nil or Version.parse(&1) == :error))
 
     case releases do
       [] -> {:error, :not_found}
       releases -> {:ok, releases}
     end
   end
+
   defp parse_json(_), do: {:error, :bad_response}
 end

--- a/lib/mode.ex
+++ b/lib/mode.ex
@@ -1,5 +1,4 @@
 defmodule Wand.Mode do
-
   @type t :: :caret | :tilde | :exact
   @no_patch ~r/^(\d+)\.(\d+)($|\+.*$|-.*$)/
 
@@ -9,6 +8,7 @@ defmodule Wand.Mode do
   end
 
   def get_requirement(mode, :latest), do: {:ok, {:latest, mode}}
+
   def get_requirement(mode, version) when is_binary(version) do
     case parse(version) do
       {:ok, version} -> {:ok, get_requirement(mode, version)}
@@ -16,23 +16,23 @@ defmodule Wand.Mode do
     end
   end
 
-  def get_requirement(:caret, %Version{major: 0, minor: 0}=version) do
+  def get_requirement(:caret, %Version{major: 0, minor: 0} = version) do
     "== #{version}"
   end
 
-  def get_requirement(:caret, %Version{major: 0}=version) do
+  def get_requirement(:caret, %Version{major: 0} = version) do
     "~> #{version}"
   end
 
-  def get_requirement(:caret, %Version{major: major}=version) do
+  def get_requirement(:caret, %Version{major: major} = version) do
     ">= #{version} and < #{major + 1}.0.0"
   end
 
-  def get_requirement(:exact, %Version{}=version) do
+  def get_requirement(:exact, %Version{} = version) do
     "== #{version}"
   end
 
-  def get_requirement(:tilde, %Version{}=version) do
+  def get_requirement(:tilde, %Version{} = version) do
     "~> #{version}"
   end
 
@@ -42,6 +42,6 @@ defmodule Wand.Mode do
   end
 
   defp parse(version) do
-    add_missing_patch(version) |> Version.parse
+    add_missing_patch(version) |> Version.parse()
   end
 end

--- a/lib/mode.ex
+++ b/lib/mode.ex
@@ -3,10 +3,15 @@ defmodule Wand.Mode do
   @type t :: :caret | :tilde | :exact
   @no_patch ~r/^(\d+)\.(\d+)($|\+.*$|-.*$)/
 
-  def get_requirement(mode, :latest), do: {:latest, mode}
+  def get_requirement!(mode, version) do
+    {:ok, requirement} = get_requirement(mode, version)
+    requirement
+  end
+
+  def get_requirement(mode, :latest), do: {:ok, {:latest, mode}}
   def get_requirement(mode, version) when is_binary(version) do
     case parse(version) do
-      {:ok, version} -> get_requirement(mode, version)
+      {:ok, version} -> {:ok, get_requirement(mode, version)}
       :error -> {:error, :invalid_version}
     end
   end

--- a/lib/mode.ex
+++ b/lib/mode.ex
@@ -1,0 +1,41 @@
+defmodule Wand.Mode do
+
+  @type t :: :caret | :tilde | :exact
+  @no_patch ~r/^(\d+)\.(\d+)($|\+.*$|-.*$)/
+
+  def get_requirement(mode, version) when is_binary(version) do
+    case parse(version) do
+      {:ok, version} -> get_requirement(mode, version)
+      :error -> {:error, :invalid_version}
+    end
+  end
+
+  def get_requirement(:caret, %Version{major: 0, minor: 0}=version) do
+    "== #{version}"
+  end
+
+  def get_requirement(:caret, %Version{major: 0}=version) do
+    "~> #{version}"
+  end
+
+  def get_requirement(:caret, %Version{major: major}=version) do
+    ">= #{version} and < #{major + 1}.0.0"
+  end
+
+  def get_requirement(:exact, %Version{}=version) do
+    "== #{version}"
+  end
+
+  def get_requirement(:tilde, %Version{}=version) do
+    "~> #{version}"
+  end
+
+  defp add_missing_patch(version) do
+    version
+    |> String.replace(@no_patch, "\\1.\\2.0\\3")
+  end
+
+  defp parse(version) do
+    add_missing_patch(version) |> Version.parse
+  end
+end

--- a/lib/mode.ex
+++ b/lib/mode.ex
@@ -3,6 +3,7 @@ defmodule Wand.Mode do
   @type t :: :caret | :tilde | :exact
   @no_patch ~r/^(\d+)\.(\d+)($|\+.*$|-.*$)/
 
+  def get_requirement(mode, :latest), do: {:latest, mode}
   def get_requirement(mode, version) when is_binary(version) do
     case parse(version) do
       {:ok, version} -> get_requirement(mode, version)

--- a/lib/wand_encoder.ex
+++ b/lib/wand_encoder.ex
@@ -2,6 +2,7 @@ defmodule Wand.WandEncoder do
   alias Wand.WandFile
   alias Wand.WandFile.Dependency
   alias Poison.Encoder
+
   defimpl Poison.Encoder, for: WandFile do
     @default_indent 2
     @default_offset 0
@@ -13,7 +14,7 @@ defmodule Wand.WandEncoder do
 
       [
         {"version", version},
-        {"dependencies", dependencies},
+        {"dependencies", dependencies}
       ]
       |> Enum.map(fn {key, value} ->
         {encode(key, options), encode(value, options)}
@@ -23,15 +24,17 @@ defmodule Wand.WandEncoder do
     end
 
     def encode([], _options), do: "{}"
+
     def encode(dependencies, options) when is_list(dependencies) do
       indent = indent(options)
       offset = offset(options) + indent
       options = offset(options, offset)
 
-      dependencies = Enum.sort_by(dependencies, &(&1.name))
-      |> Enum.map(fn dependency ->
-        {encode(dependency.name, options), encode(dependency, options)}
-      end)
+      dependencies =
+        Enum.sort_by(dependencies, & &1.name)
+        |> Enum.map(fn dependency ->
+          {encode(dependency.name, options), encode(dependency, options)}
+        end)
 
       create_map_body(dependencies, offset)
       |> wrap_map(offset, indent)

--- a/test/commands/add_execute_test.exs
+++ b/test/commands/add_execute_test.exs
@@ -109,7 +109,7 @@ defmodule AddExecuteTest do
     test ":file_write_error when trying to save the file" do
       Helpers.WandFile.stub_load()
       %WandFile{
-        dependencies: [%Dependency{name: "poison", requirement: "~> 3.1.0"}]
+        dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.0 and < 4.0.0"}]
       }
       |> Helpers.WandFile.stub_cannot_save()
       assert Add.execute([@poison]) == error(:file_write_error)
@@ -120,7 +120,7 @@ defmodule AddExecuteTest do
     Helpers.WandFile.stub_load()
     Helpers.Hex.stub_poison()
     %WandFile{
-      dependencies: [%Dependency{name: "poison", requirement: "~> 3.1.0"}]
+      dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.0 and < 4.0.0"}]
     }
     |> Helpers.WandFile.stub_save()
     assert Add.execute([@poison]) == :ok
@@ -129,10 +129,10 @@ defmodule AddExecuteTest do
   test "add a package with a version" do
     Helpers.WandFile.stub_load()
     %WandFile{
-      dependencies: [%Dependency{name: "poison", requirement: "~> 3.1.3"}]
+      dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.3 and < 4.0.0"}]
     }
     |> Helpers.WandFile.stub_save()
-    package = %Package{name: "poison", requirement: "3.1.3"}
+    package = %Package{name: "poison", requirement: ">= 3.1.3 and < 4.0.0"}
     assert Add.execute([package]) == :ok
   end
 
@@ -142,7 +142,7 @@ defmodule AddExecuteTest do
       dependencies: [%Dependency{name: "poison", requirement: "== 3.1.2"}]
     }
     |> Helpers.WandFile.stub_save()
-    package = %Package{name: "poison", requirement: "3.1.2", mode: :exact}
+    package = %Package{name: "poison", requirement: "== 3.1.2"}
     assert Add.execute([package]) == :ok
 
   end

--- a/test/commands/add_execute_test.exs
+++ b/test/commands/add_execute_test.exs
@@ -56,7 +56,7 @@ defmodule AddExecuteTest do
 
     test ":invalid_wand_file when a dependency is invalid" do
       Helpers.WandFile.stub_file_bad_dependency()
-        assert Add.execute([@poison]) == error(:invalid_wand_file)
+      assert Add.execute([@poison]) == error(:invalid_wand_file)
     end
   end
 
@@ -93,25 +93,28 @@ defmodule AddExecuteTest do
     test ":package_already_exists when poison already exists" do
       %WandFile{
         dependencies: [
-          %Dependency{name: "poison", requirement: "~> 3.1"},
+          %Dependency{name: "poison", requirement: "~> 3.1"}
         ]
       }
       |> Helpers.WandFile.stub_load()
+
       assert Add.execute([@poison]) == error(:package_already_exists)
     end
 
     test ":package_already_exists when trying to add the same package twice" do
       Helpers.WandFile.stub_load()
       Helpers.Hex.stub_poison()
-        assert Add.execute([@poison, @poison]) == error(:package_already_exists)
+      assert Add.execute([@poison, @poison]) == error(:package_already_exists)
     end
 
     test ":file_write_error when trying to save the file" do
       Helpers.WandFile.stub_load()
+
       %WandFile{
         dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.0 and < 4.0.0"}]
       }
       |> Helpers.WandFile.stub_cannot_save()
+
       assert Add.execute([@poison]) == error(:file_write_error)
     end
   end
@@ -119,31 +122,36 @@ defmodule AddExecuteTest do
   test "adds a single package" do
     Helpers.WandFile.stub_load()
     Helpers.Hex.stub_poison()
+
     %WandFile{
       dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.0 and < 4.0.0"}]
     }
     |> Helpers.WandFile.stub_save()
+
     assert Add.execute([@poison]) == :ok
   end
 
   test "add a package with a version" do
     Helpers.WandFile.stub_load()
+
     %WandFile{
       dependencies: [%Dependency{name: "poison", requirement: ">= 3.1.3 and < 4.0.0"}]
     }
     |> Helpers.WandFile.stub_save()
+
     package = %Package{name: "poison", requirement: ">= 3.1.3 and < 4.0.0"}
     assert Add.execute([package]) == :ok
   end
 
   test "add a package with the exact version" do
     Helpers.WandFile.stub_load()
+
     %WandFile{
       dependencies: [%Dependency{name: "poison", requirement: "== 3.1.2"}]
     }
     |> Helpers.WandFile.stub_save()
+
     package = %Package{name: "poison", requirement: "== 3.1.2"}
     assert Add.execute([package]) == :ok
-
   end
 end

--- a/test/commands/add_execute_test.exs
+++ b/test/commands/add_execute_test.exs
@@ -125,4 +125,25 @@ defmodule AddExecuteTest do
     |> Helpers.WandFile.stub_save()
     assert Add.execute([@poison]) == :ok
   end
+
+  test "add a package with a version" do
+    Helpers.WandFile.stub_load()
+    %WandFile{
+      dependencies: [%Dependency{name: "poison", requirement: "~> 3.1.3"}]
+    }
+    |> Helpers.WandFile.stub_save()
+    package = %Package{name: "poison", requirement: "3.1.3"}
+    assert Add.execute([package]) == :ok
+  end
+
+  test "add a package with the exact version" do
+    Helpers.WandFile.stub_load()
+    %WandFile{
+      dependencies: [%Dependency{name: "poison", requirement: "== 3.1.2"}]
+    }
+    |> Helpers.WandFile.stub_save()
+    package = %Package{name: "poison", requirement: "3.1.2", mode: :exact}
+    assert Add.execute([package]) == :ok
+
+  end
 end

--- a/test/commands/add_test.exs
+++ b/test/commands/add_test.exs
@@ -269,6 +269,10 @@ defmodule AddTest do
       Add.help({:invalid_flag, "--foobaz"})
     end
 
+    test "invalid_version" do
+      Add.help({:invalid_version, "poison@-3.1.0"})
+    end
+
     def stub_io(_) do
       expect(Wand.IOMock, :puts, fn _message -> :ok end)
       :ok

--- a/test/commands/add_test.exs
+++ b/test/commands/add_test.exs
@@ -19,6 +19,11 @@ defmodule AddTest do
       assert Add.validate(command) == {:error, {:invalid_flag, "--sparse"}}
     end
 
+    test "returns help if the version is invalid" do
+      assert Add.validate(["add", "poison@NOT_A_VERSION"]) ==
+               {:error, {:invalid_version, "poison@NOT_A_VERSION"}}
+    end
+
     test "returns help if a flag for the wrong file type is given" do
       command = OptionParser.split("add ex_doc --path=/test --hex-name=foo")
       assert Add.validate(command) == {:error, {:invalid_flag, "--hex-name"}}

--- a/test/commands/add_test.exs
+++ b/test/commands/add_test.exs
@@ -177,7 +177,8 @@ defmodule AddTest do
            }
          ]}
 
-      assert Add.validate(["add", "poison", "--git=https://github.com/devinus/poison.git"]) == expected
+      assert Add.validate(["add", "poison", "--git=https://github.com/devinus/poison.git"]) ==
+               expected
     end
 
     test "a http git package with a version" do
@@ -193,7 +194,8 @@ defmodule AddTest do
            }
          ]}
 
-      assert Add.validate(["add", "poison@3.1", "--git=https://github.com/devinus/poison.git"]) == expected
+      assert Add.validate(["add", "poison@3.1", "--git=https://github.com/devinus/poison.git"]) ==
+               expected
     end
 
     test "a ssh github package" do
@@ -209,7 +211,8 @@ defmodule AddTest do
            }
          ]}
 
-      assert Add.validate(["add", "poison@3.1", "--git=git@github.com:devinus/poison"]) == expected
+      assert Add.validate(["add", "poison@3.1", "--git=git@github.com:devinus/poison"]) ==
+               expected
     end
 
     test "a ssh github package with a ref" do

--- a/test/commands/add_test.exs
+++ b/test/commands/add_test.exs
@@ -3,7 +3,7 @@ defmodule AddTest do
   import Mox
   alias Wand.CLI.Commands.Add
   alias Wand.CLI.Commands.Add.{Git, Hex, Package, Path}
-  
+
   describe "validate" do
     test "returns help if no args are given" do
       assert Add.validate(["add"]) == {:error, :missing_package}
@@ -58,7 +58,7 @@ defmodule AddTest do
 
     test "a package with a specific version" do
       assert Add.validate(["add", "poison@3.1"]) ==
-               {:ok, [%Package{name: "poison", requirement: "3.1"}]}
+               {:ok, [%Package{name: "poison", requirement: ">= 3.1.0 and < 4.0.0"}]}
     end
 
     test "a package only for the test environment" do
@@ -120,12 +120,12 @@ defmodule AddTest do
 
     test "an exact match" do
       assert Add.validate(["add", "ex_doc", "--exact"]) ==
-               {:ok, [%Package{name: "ex_doc", mode: :exact}]}
+               {:ok, [%Package{name: "ex_doc", requirement: {:latest, :exact}}]}
     end
 
     test "Install the closest minor version" do
-      assert Add.validate(["add", "ex_doc", "--around"]) ==
-               {:ok, [%Package{name: "ex_doc", mode: :around}]}
+      assert Add.validate(["add", "ex_doc", "--tilde"]) ==
+               {:ok, [%Package{name: "ex_doc", requirement: {:latest, :tilde}}]}
     end
 
     test "a local umbrella package" do
@@ -181,7 +181,7 @@ defmodule AddTest do
          [
            %Package{
              name: "poison",
-             requirement: "3.1",
+             requirement: ">= 3.1.0 and < 4.0.0",
              details: %Git{
                uri: "https://github.com/devinus/poison.git"
              }
@@ -197,7 +197,7 @@ defmodule AddTest do
          [
            %Package{
              name: "poison",
-             requirement: "3.1",
+             requirement: ">= 3.1.0 and < 4.0.0",
              details: %Git{
                uri: "git@github.com:devinus/poison"
              }

--- a/test/commands/version_test.exs
+++ b/test/commands/version_test.exs
@@ -1,4 +1,4 @@
-defmodule VersionTest do
+defmodule CLI.VersionTest do
   use ExUnit.Case, async: true
   import Mox
   alias Wand.CLI.Commands.Version

--- a/test/display_test.exs
+++ b/test/display_test.exs
@@ -106,6 +106,6 @@ defmodule DisplayTest do
 
   defp stub_stderr(message) do
     message = @r <> "\n" <> message <> "\n" <> @rr
-    expect(Wand.IOMock, :puts, fn(:stderr, ^message) -> :ok end)
+    expect(Wand.IOMock, :puts, fn :stderr, ^message -> :ok end)
   end
 end

--- a/test/hex_test.exs
+++ b/test/hex_test.exs
@@ -38,9 +38,32 @@ defmodule HexTest do
 
   test "returns the releases" do
     stub_http(:ok, 200, valid_body())
-    expected = {:ok, ["3.1.0", "3.0.0", "2.2.0", "2.1.0", "2.0.1", "2.0.0", "1.5.2",
-             "1.5.1", "1.5.0", "1.4.0", "1.3.1", "1.3.0", "1.2.1", "1.2.0",
-             "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"]}
+
+    expected =
+      {:ok,
+       [
+         "3.1.0",
+         "3.0.0",
+         "2.2.0",
+         "2.1.0",
+         "2.0.1",
+         "2.0.0",
+         "1.5.2",
+         "1.5.1",
+         "1.5.0",
+         "1.4.0",
+         "1.3.1",
+         "1.3.0",
+         "1.2.1",
+         "1.2.0",
+         "1.1.1",
+         "1.1.0",
+         "1.0.3",
+         "1.0.2",
+         "1.0.1",
+         "1.0.0"
+       ]}
+
     assert Hex.releases("poison") == expected
   end
 
@@ -49,24 +72,28 @@ defmodule HexTest do
       releases: [
         %{version: "1.1.0"},
         %{missing_version: "1.1.0"},
-        %{version: "ABC"},
+        %{version: "ABC"}
       ]
     })
+
     assert Hex.releases("poison") == {:ok, ["1.1.0"]}
   end
 
-  defp stub_http(:ok, status, %{}=contents), do: stub_http(:ok, status, Poison.encode!(contents))
+  defp stub_http(:ok, status, %{} = contents),
+    do: stub_http(:ok, status, Poison.encode!(contents))
+
   defp stub_http(:ok, status, contents) do
     response = %Response{
       status_code: status,
-      body: contents,
+      body: contents
     }
+
     expect(Wand.HttpMock, :get, fn _url, _headers -> {:ok, response} end)
   end
 
   defp stub_http(:error) do
     response = %Error{id: nil, reason: :nxdomain}
-    expect(Wand.HttpMock, :get, fn(_url, _headers) -> {:error, response} end)
+    expect(Wand.HttpMock, :get, fn _url, _headers -> {:error, response} end)
   end
 
   defp valid_body() do

--- a/test/mode_test.exs
+++ b/test/mode_test.exs
@@ -3,71 +3,83 @@ defmodule ModeTest do
 
   describe "caret" do
     test "allows no updates for 0.0.1" do
-      assert Wand.Mode.get_requirement(:caret, "0.0.1") == "== 0.0.1"
+      assert Wand.Mode.get_requirement(:caret, "0.0.1") == {:ok, "== 0.0.1"}
     end
 
     test "allows no updates for 0.0.7-dev" do
-      assert Wand.Mode.get_requirement(:caret, "0.0.7-dev") == "== 0.0.7-dev"
+      assert Wand.Mode.get_requirement(:caret, "0.0.7-dev") == {:ok, "== 0.0.7-dev"}
     end
 
     test "allows ~> updates for 0.1.2" do
-      assert Wand.Mode.get_requirement(:caret, "0.1.2") == "~> 0.1.2"
+      assert Wand.Mode.get_requirement(:caret, "0.1.2") == {:ok, "~> 0.1.2"}
     end
 
     test "allows all minor updates for 3.4.5" do
-      assert Wand.Mode.get_requirement(:caret, "3.4.5") == ">= 3.4.5 and < 4.0.0"
+      assert Wand.Mode.get_requirement(:caret, "3.4.5") == {:ok, ">= 3.4.5 and < 4.0.0"}
     end
 
     test "Parses 0.1 as 0.1.0" do
-      assert Wand.Mode.get_requirement(:caret, "0.1") == "~> 0.1.0"
+      assert Wand.Mode.get_requirement(:caret, "0.1") == {:ok, "~> 0.1.0"}
     end
 
     test "Parses 0.1-dev as 0.1.0-dev" do
-      assert Wand.Mode.get_requirement(:caret, "0.1-dev") == "~> 0.1.0-dev"
+      assert Wand.Mode.get_requirement(:caret, "0.1-dev") == {:ok, "~> 0.1.0-dev"}
     end
 
     test "Parses 3.1 as 3.1.0" do
-      assert Wand.Mode.get_requirement(:caret, "3.1") == ">= 3.1.0 and < 4.0.0"
+      assert Wand.Mode.get_requirement(:caret, "3.1") == {:ok, ">= 3.1.0 and < 4.0.0"}
     end
 
     test "latest" do
-      assert Wand.Mode.get_requirement(:caret, :latest) == {:latest, :caret}
+      assert Wand.Mode.get_requirement(:caret, :latest) == {:ok, {:latest, :caret}}
     end
   end
 
   describe "exact" do
     test "0.0.1" do
-      assert Wand.Mode.get_requirement(:exact, "0.0.1") == "== 0.0.1"
+      assert Wand.Mode.get_requirement(:exact, "0.0.1") == {:ok, "== 0.0.1"}
     end
 
     test "0.1.2-dev" do
-      assert Wand.Mode.get_requirement(:exact, "0.1.2-dev") == "== 0.1.2-dev"
+      assert Wand.Mode.get_requirement(:exact, "0.1.2-dev") == {:ok, "== 0.1.2-dev"}
     end
 
     test "3.1.2+build1" do
-      assert Wand.Mode.get_requirement(:exact, "3.1.2+build1") == "== 3.1.2+build1"
+      assert Wand.Mode.get_requirement(:exact, "3.1.2+build1") == {:ok, "== 3.1.2+build1"}
     end
 
     test "latest" do
-      assert Wand.Mode.get_requirement(:exact, :latest) == {:latest, :exact}
+      assert Wand.Mode.get_requirement(:exact, :latest) == {:ok, {:latest, :exact}}
     end
   end
 
   describe "tilde" do
     test "0.0.1" do
-      assert Wand.Mode.get_requirement(:tilde, "0.0.1") == "~> 0.0.1"
+      assert Wand.Mode.get_requirement(:tilde, "0.0.1") == {:ok, "~> 0.0.1"}
     end
 
     test "0.1.2-dev" do
-      assert Wand.Mode.get_requirement(:tilde, "0.1.2-dev") == "~> 0.1.2-dev"
+      assert Wand.Mode.get_requirement(:tilde, "0.1.2-dev") == {:ok, "~> 0.1.2-dev"}
     end
 
     test "3.1.2+build1" do
-      assert Wand.Mode.get_requirement(:tilde, "3.1.2+build1") == "~> 3.1.2+build1"
+      assert Wand.Mode.get_requirement(:tilde, "3.1.2+build1") == {:ok, "~> 3.1.2+build1"}
     end
 
     test "latest" do
-      assert Wand.Mode.get_requirement(:tilde, :latest) == {:latest, :tilde}
+      assert Wand.Mode.get_requirement(:tilde, :latest) == {:ok, {:latest, :tilde}}
+    end
+  end
+
+  describe "get_requirement!" do
+    test "returns the requirement on success" do
+      assert Wand.Mode.get_requirement!(:tilde, "0.0.1") == "~> 0.0.1"
+    end
+
+    test "raieses an exception on failure" do
+      assert_raise(MatchError, fn ->
+        Wand.Mode.get_requirement!(:tilde, "NOT_A_VERSION") == "~> 0.0.1"
+      end)
     end
   end
 end

--- a/test/mode_test.exs
+++ b/test/mode_test.exs
@@ -29,6 +29,10 @@ defmodule ModeTest do
     test "Parses 3.1 as 3.1.0" do
       assert Wand.Mode.get_requirement(:caret, "3.1") == ">= 3.1.0 and < 4.0.0"
     end
+
+    test "latest" do
+      assert Wand.Mode.get_requirement(:caret, :latest) == {:latest, :caret}
+    end
   end
 
   describe "exact" do
@@ -43,6 +47,10 @@ defmodule ModeTest do
     test "3.1.2+build1" do
       assert Wand.Mode.get_requirement(:exact, "3.1.2+build1") == "== 3.1.2+build1"
     end
+
+    test "latest" do
+      assert Wand.Mode.get_requirement(:exact, :latest) == {:latest, :exact}
+    end
   end
 
   describe "tilde" do
@@ -56,6 +64,10 @@ defmodule ModeTest do
 
     test "3.1.2+build1" do
       assert Wand.Mode.get_requirement(:tilde, "3.1.2+build1") == "~> 3.1.2+build1"
+    end
+
+    test "latest" do
+      assert Wand.Mode.get_requirement(:tilde, :latest) == {:latest, :tilde}
     end
   end
 end

--- a/test/mode_test.exs
+++ b/test/mode_test.exs
@@ -1,0 +1,61 @@
+defmodule ModeTest do
+  use ExUnit.Case, async: true
+
+  describe "caret" do
+    test "allows no updates for 0.0.1" do
+      assert Wand.Mode.get_requirement(:caret, "0.0.1") == "== 0.0.1"
+    end
+
+    test "allows no updates for 0.0.7-dev" do
+      assert Wand.Mode.get_requirement(:caret, "0.0.7-dev") == "== 0.0.7-dev"
+    end
+
+    test "allows ~> updates for 0.1.2" do
+      assert Wand.Mode.get_requirement(:caret, "0.1.2") == "~> 0.1.2"
+    end
+
+    test "allows all minor updates for 3.4.5" do
+      assert Wand.Mode.get_requirement(:caret, "3.4.5") == ">= 3.4.5 and < 4.0.0"
+    end
+
+    test "Parses 0.1 as 0.1.0" do
+      assert Wand.Mode.get_requirement(:caret, "0.1") == "~> 0.1.0"
+    end
+
+    test "Parses 0.1-dev as 0.1.0-dev" do
+      assert Wand.Mode.get_requirement(:caret, "0.1-dev") == "~> 0.1.0-dev"
+    end
+
+    test "Parses 3.1 as 3.1.0" do
+      assert Wand.Mode.get_requirement(:caret, "3.1") == ">= 3.1.0 and < 4.0.0"
+    end
+  end
+
+  describe "exact" do
+    test "0.0.1" do
+      assert Wand.Mode.get_requirement(:exact, "0.0.1") == "== 0.0.1"
+    end
+
+    test "0.1.2-dev" do
+      assert Wand.Mode.get_requirement(:exact, "0.1.2-dev") == "== 0.1.2-dev"
+    end
+
+    test "3.1.2+build1" do
+      assert Wand.Mode.get_requirement(:exact, "3.1.2+build1") == "== 3.1.2+build1"
+    end
+  end
+
+  describe "tilde" do
+    test "0.0.1" do
+      assert Wand.Mode.get_requirement(:tilde, "0.0.1") == "~> 0.0.1"
+    end
+
+    test "0.1.2-dev" do
+      assert Wand.Mode.get_requirement(:tilde, "0.1.2-dev") == "~> 0.1.2-dev"
+    end
+
+    test "3.1.2+build1" do
+      assert Wand.Mode.get_requirement(:tilde, "3.1.2+build1") == "~> 3.1.2+build1"
+    end
+  end
+end

--- a/test/support/hex.ex
+++ b/test/support/hex.ex
@@ -1,20 +1,38 @@
 defmodule Wand.Test.Helpers.Hex do
   import Mox
-  alias HTTPoison.{Error,Response}
+  alias HTTPoison.{Error, Response}
 
   def stub_poison() do
-    releases = [
-      "3.1.0", "3.0.0", "2.2.0", "2.1.0", "2.0.1", "2.0.0", "1.5.2",
-      "1.5.1", "1.5.0", "1.4.0", "1.3.1", "1.3.0", "1.2.1", "1.2.0",
-      "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"
-    ]
-    |> Enum.map(&(%{version: &1}))
+    releases =
+      [
+        "3.1.0",
+        "3.0.0",
+        "2.2.0",
+        "2.1.0",
+        "2.0.1",
+        "2.0.0",
+        "1.5.2",
+        "1.5.1",
+        "1.5.0",
+        "1.4.0",
+        "1.3.1",
+        "1.3.0",
+        "1.2.1",
+        "1.2.0",
+        "1.1.1",
+        "1.1.0",
+        "1.0.3",
+        "1.0.2",
+        "1.0.1",
+        "1.0.0"
+      ]
+      |> Enum.map(&%{version: &1})
 
-    body =  %{releases: releases} |> Poison.encode!()
+    body = %{releases: releases} |> Poison.encode!()
 
     %Response{
       body: body,
-      status_code: 200,
+      status_code: 200
     }
     |> stub_http()
   end
@@ -22,7 +40,7 @@ defmodule Wand.Test.Helpers.Hex do
   def stub_not_found() do
     %Response{
       body: "",
-      status_code: 404,
+      status_code: 404
     }
     |> stub_http()
   end
@@ -35,13 +53,13 @@ defmodule Wand.Test.Helpers.Hex do
   def stub_bad_response() do
     %Response{
       body: "[NOT JSON",
-      status_code: 200,
+      status_code: 200
     }
     |> stub_http()
   end
 
   defp stub_http(response, type \\ :ok) do
     uri = URI.parse("https://hex.pm/api/packages/poison")
-    expect(Wand.HttpMock, :get, fn(^uri, _headers) -> {type, response} end)
+    expect(Wand.HttpMock, :get, fn ^uri, _headers -> {type, response} end)
   end
 end

--- a/test/support/io.ex
+++ b/test/support/io.ex
@@ -1,10 +1,11 @@
 defmodule Wand.Test.Helpers.IO do
   import Mox
+
   def stub_io() do
-    expect(Wand.IOMock, :puts, fn(_message)-> :ok end)
+    expect(Wand.IOMock, :puts, fn _message -> :ok end)
   end
 
   def stub_stderr() do
-    expect(Wand.IOMock, :puts, fn(:stderr, _message) -> :ok end)
+    expect(Wand.IOMock, :puts, fn :stderr, _message -> :ok end)
   end
 end

--- a/test/support/wand_file.ex
+++ b/test/support/wand_file.ex
@@ -27,39 +27,47 @@ defmodule Wand.Test.Helpers.WandFile do
   end
 
   def stub_file_wrong_dependencies() do
-    contents = %{
-      version: "1.0.0",
-      dependencies: "not requirements",
-    }
-    |> Poison.encode!()
+    contents =
+      %{
+        version: "1.0.0",
+        dependencies: "not requirements"
+      }
+      |> Poison.encode!()
+
     stub_read(contents)
   end
 
   def stub_file_bad_dependency() do
-    contents = %{
-      version: "1.0.0",
-      dependencies: %{
-        mox: "== == 1.0.0"
+    contents =
+      %{
+        version: "1.0.0",
+        dependencies: %{
+          mox: "== == 1.0.0"
+        }
       }
-    }
-    |> Poison.encode!()
+      |> Poison.encode!()
+
     expect(Wand.FileMock, :read, fn _path -> {:ok, contents} end)
   end
 
   def stub_file_wrong_version(version) do
-    contents = %{
-      version: version,
-      requirements: [],
-    }
-    |> Poison.encode!()
+    contents =
+      %{
+        version: version,
+        requirements: []
+      }
+      |> Poison.encode!()
+
     stub_read(contents)
   end
 
   def stub_file_missing_version() do
-    contents = %{
-      requirements: []
-    }
-    |> Poison.encode!()
+    contents =
+      %{
+        requirements: []
+      }
+      |> Poison.encode!()
+
     stub_read(contents)
   end
 

--- a/test/wand_file_test.exs
+++ b/test/wand_file_test.exs
@@ -57,12 +57,14 @@ defmodule WandFileTest do
     end
 
     test ":invalid dependency when a dependency is invalid" do
-      json = Poison.encode!(%{
-        version: "1.0.0",
-        dependencies: %{
-          mox: "== == 1.0.0"
-        }
-      })
+      json =
+        Poison.encode!(%{
+          version: "1.0.0",
+          dependencies: %{
+            mox: "== == 1.0.0"
+          }
+        })
+
       stub_read(:ok, "wand.json", json)
       assert WandFile.load() == {:error, {:invalid_dependency, "mox"}}
     end
@@ -74,6 +76,7 @@ defmodule WandFileTest do
       dependency = poison("~> 3.3")
       assert WandFile.add(file, dependency) == {:error, {:already_exists, "poison"}}
     end
+
     test "a new package" do
       file = %WandFile{}
       dependency = poison()
@@ -91,24 +94,30 @@ defmodule WandFileTest do
   end
 
   describe "save" do
-
     test ":enoent if saving fails" do
       file = %WandFile{}
-      contents = %{
-        version: file.version,
-        dependencies: %{},
-      }
-      |> Poison.encode!(pretty: true)
+
+      contents =
+        %{
+          version: file.version,
+          dependencies: %{}
+        }
+        |> Poison.encode!(pretty: true)
+
       stub_write(:error, "wand.json", contents)
       assert WandFile.save(file) == {:error, :enoent}
     end
+
     test "saves an empty config" do
       file = %WandFile{}
-      expected = %{
-        version: file.version,
-        dependencies: %{},
-      }
-      |> Poison.encode!(pretty: true)
+
+      expected =
+        %{
+          version: file.version,
+          dependencies: %{}
+        }
+        |> Poison.encode!(pretty: true)
+
       stub_write(:ok, "wand.json", expected)
       assert WandFile.save(file) == :ok
     end
@@ -117,13 +126,15 @@ defmodule WandFileTest do
       dependency = poison()
       {:ok, file} = WandFile.add(%WandFile{}, dependency)
 
-      expected = %{
-        version: file.version,
-        dependencies: %{
-          "poison" => "~> 3.1",
+      expected =
+        %{
+          version: file.version,
+          dependencies: %{
+            "poison" => "~> 3.1"
+          }
         }
-      }
-      |> Poison.encode!(pretty: true)
+        |> Poison.encode!(pretty: true)
+
       stub_write(:ok, "wand.json", expected)
       WandFile.save(file)
     end
@@ -134,10 +145,13 @@ defmodule WandFileTest do
         %Dependency{name: "b", requirement: "~> 3.2"},
         %Dependency{name: "a", requirement: "~> 3.1"},
         %Dependency{name: "f", requirement: "~> 3.5"},
-        %Dependency{name: "c", requirement: "~> 3.3"},
+        %Dependency{name: "c", requirement: "~> 3.3"}
       ]
+
       file = %WandFile{dependencies: dependencies}
-      expected = "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"a\": \"~> 3.1\",\n    \"b\": \"~> 3.2\",\n    \"c\": \"~> 3.3\",\n    \"d\": \"~> 3.4\",\n    \"f\": \"~> 3.5\"\n  }\n}"
+
+      expected =
+        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"a\": \"~> 3.1\",\n    \"b\": \"~> 3.2\",\n    \"c\": \"~> 3.3\",\n    \"d\": \"~> 3.4\",\n    \"f\": \"~> 3.5\"\n  }\n}"
 
       stub_write(:ok, "wand.json", expected)
       WandFile.save(file)
@@ -145,7 +159,9 @@ defmodule WandFileTest do
 
     test "dependencies with opts" do
       file = %WandFile{dependencies: [mox()]}
-      expected = "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\n      \"~> 0.3.2\",\n      {\n        \"only\": \"test\"\n      }\n    ]\n  }\n}"
+
+      expected =
+        "{\n  \"version\": \"1.0.0\",\n  \"dependencies\": {\n    \"mox\": [\n      \"~> 0.3.2\",\n      {\n        \"only\": \"test\"\n      }\n    ]\n  }\n}"
 
       stub_write(:ok, "wand.json", expected)
       WandFile.save(file)
@@ -168,11 +184,11 @@ defmodule WandFileTest do
   end
 
   defp stub_write(:ok, path, contents) do
-    expect(Wand.FileMock, :write, fn(^path, ^contents) -> :ok end)
+    expect(Wand.FileMock, :write, fn ^path, ^contents -> :ok end)
   end
 
   defp stub_write(:error, path, contents) do
-    expect(Wand.FileMock, :write, fn(^path, ^contents) -> {:error, :enoent} end)
+    expect(Wand.FileMock, :write, fn ^path, ^contents -> {:error, :enoent} end)
   end
 
   defp valid_deps() do
@@ -180,7 +196,7 @@ defmodule WandFileTest do
       version: "1.0.1",
       dependencies: %{
         mox: ["~> 0.3.2", %{only: "test"}],
-        poison: "~> 3.1",
+        poison: "~> 3.1"
       }
     }
   end
@@ -190,7 +206,7 @@ defmodule WandFileTest do
       version: "1.0.1",
       dependencies: [
         mox(),
-        poison(),
+        poison()
       ]
     }
   end


### PR DESCRIPTION
Supports when a version is passed in, e.g. `wand add poison@3.1`